### PR TITLE
Update demo identity server URL

### DIFF
--- a/SwashbucklePkce/appsettings.json
+++ b/SwashbucklePkce/appsettings.json
@@ -3,7 +3,7 @@
     "Jwt": {
       "ClientId": "interactive.public",
       "Audience": "api",
-      "Authority": "https://demo.identityserver.io"
+      "Authority": "https://demo.identityserver.com"
     }
   },
   "Logging": {


### PR DESCRIPTION
I couldn't get the app to run on my machine. After digging around for a bit it seemed like the identity server wasn't returning any results. After a bit of googling I discovered that they have apparently moved the demo to the .com TLD.